### PR TITLE
src/nl_extras.h: fix compatibility with libnl 3.3.0

### DIFF
--- a/src/nl_extras.h
+++ b/src/nl_extras.h
@@ -1,7 +1,7 @@
 #ifndef __NL_EXTRAS_H
 #define __NL_EXTRAS_H
 
-#if LIBNL_VER_MIC <= 26
+#if (LIBNL_VER_MIN < 2) || (LIBNL_VER_MIN == 2) && (LIBNL_VER_MIC <= 26)
 
 #ifndef NLA_S8
 
@@ -45,6 +45,6 @@ static inline int32_t nla_get_s32(struct nlattr *nla)
 
 #endif /* NLA_S64 */
 
-#endif /* LIBNL_VER_MIC */
+#endif /* LIBNL_VER_* */
 
 #endif /* __NL_EXTRAS_H */


### PR DESCRIPTION
nl_extras.h defines a set of nla_set_s*() functions if not provided by
libnl. They are provided by libnl since version 3.2.26. The test
(LIBNL_VER_MIC <= 26) was working fine while libnl was in the 3.2.x
series, but now that they have incremented the minor version, the
micro version was reset to 0, with the latest libnl version being
3.3.0.

Due to this, the condition (LIBNL_VER_MIC <= 26) is true, and we get
redefinition errors because nl_extras.h redefines functions already
provided by libnl.

This commit improves the condition so that nl_extras.h provides the
missing functions only if the minor version is < 2, or if minor is 2
and micro is < 26.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>